### PR TITLE
fix(STARGATE-553): trying to download expired artifact

### DIFF
--- a/gha-cache/angular.ts
+++ b/gha-cache/angular.ts
@@ -16,6 +16,7 @@ interface CacheConfig {
 interface Artifact {
   name: string;
   archive_download_url: string;
+  expires_at: string;
 }
 
 interface Config {
@@ -161,7 +162,7 @@ function getCachePath(cacheItem: CacheItem, key: string): string {
 
 async function downloadCache(name: string, cacheItem: CacheItem, key: string) {
   const artifact = await getArtifact(name);
-  if (!artifact) {
+  if (!artifact || new Date(artifact.expires_at).getTime() < new Date().getTime()) {
     return false;
   }
   const cachePath = `temp${Math.random()}.zip`;


### PR DESCRIPTION
it was wrongly assumed that when the artifact expires, the API won't return it, but the API does still return expired artifacts for sometime after they are expired, so we need to check if it's expired before trying to download it